### PR TITLE
add Dockerfile

### DIFF
--- a/DB/Dockerfile
+++ b/DB/Dockerfile
@@ -1,0 +1,12 @@
+FROM postgres:16.0
+
+# copy local DB_SCHEMA.sql to /docker-entrypoint-initdb.d
+# /docker-entrypoint-initdb.d will init schema
+COPY DB_SCHEMA.sql /docker-entrypoint-initdb.d/
+
+# set user and password
+ENV POSTGRES_USER=admin
+ENV POSTGRES_PASSWORD=password
+
+# expose port
+EXPOSE 5432


### PR DESCRIPTION
## add Dockerfile
Use DB_SCHEMA.sql to init schema

### Step1 . build image
`docker build -f Dockerfile -t orange/postgres:16.0 .`

### Step2. run container
`docker run --name postgres_container -p 5432:5432 -v postgres-volume:/var/lib/postgresql/data -d orange/postgres:16.0`

---

### Trace logs to check schema init
`docker logs <container_id>`

---

### Notice
* makesure  tho volume is new, 
if volume is old, the schema will not init
